### PR TITLE
Restore semantics missing after refactor in #9

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -21,7 +21,7 @@ contributors: Ron Buckton, Ecma International
   <emu-clause id="sec-syntax-directed-operations-scope-analysis" number="2">
     <h1>Scope Analysis</h1>
 
-    <emu-clause id="sec-static-semantics-boundnames" oldids="sec-identifiers-static-semantics-boundnames,sec-let-and-const-declarations-static-semantics-boundnames,sec-variable-statement-static-semantics-boundnames,sec-destructuring-binding-patterns-static-semantics-boundnames,sec-for-in-and-for-of-statements-static-semantics-boundnames,sec-function-definitions-static-semantics-boundnames,sec-arrow-function-definitions-static-semantics-boundnames,sec-generator-function-definitions-static-semantics-boundnames,sec-async-generator-function-definitions-static-semantics-boundnames,sec-class-definitions-static-semantics-boundnames,sec-async-function-definitions-static-semantics-BoundNames,sec-async-arrow-function-definitions-static-semantics-BoundNames,sec-imports-static-semantics-boundnames,sec-exports-static-semantics-boundnames" type="sdo">
+    <emu-clause id="sec-static-semantics-boundnames" type="sdo">
       <h1>Static Semantics: BoundNames ( ): a List of Strings</h1>
       <dl class="header">
       </dl>
@@ -297,67 +297,162 @@ contributors: Ron Buckton, Ecma International
 
   <emu-clause id="sec-syntax-directed-operations-miscellaneous" number="6">
     <h1>Miscellaneous</h1>
-    <emu-clause id="sec-runtime-semantics-bindinginitialization" oldids="sec-identifiers-runtime-semantics-bindinginitialization,sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization" type="sdo">
+
+    <emu-clause id="sec-runtime-semantics-iteratorbindinginitialization" otype="sdo" number="3">
       <h1>
-        Runtime Semantics: BindingInitialization (
-          _value_: an ECMAScript language value,
+        Runtime Semantics: IteratorBindingInitialization (
+          _iteratorRecord_: an Iterator Record,
           _environment_: an Environment Record or *undefined*,
         ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-note>
-        <p>*undefined* is passed for _environment_ to indicate that a PutValue operation should be used to assign the initialization value. This is the case for `var` statements and formal parameter lists of some non-strict functions (See <emu-xref href="#sec-functiondeclarationinstantiation"></emu-xref>). In those cases a lexical binding is hoisted and preinitialized prior to evaluation of its initializer.</p>
+        <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
       </emu-note>
-      <emu-grammar>BindingIdentifier : Identifier</emu-grammar>
-      <emu-alg>
-        1. Let _name_ be StringValue of |Identifier|.
-        1. Return ? InitializeBoundName(_name_, _value_, _environment_).
-      </emu-alg>
-      <emu-grammar>BindingIdentifier : `yield`</emu-grammar>
-      <emu-alg>
-        1. Return ? InitializeBoundName(*"yield"*, _value_, _environment_).
-      </emu-alg>
-      <emu-grammar>BindingIdentifier : `await`</emu-grammar>
-      <emu-alg>
-        1. Return ? InitializeBoundName(*"await"*, _value_, _environment_).
-      </emu-alg>
-      <emu-grammar>BindingPattern : ObjectBindingPattern</emu-grammar>
-      <emu-alg>
-        1. Perform ? RequireObjectCoercible(_value_).
-        1. Return ? BindingInitialization of |ObjectBindingPattern| with arguments _value_ and _environment_.
-      </emu-alg>
-      <emu-grammar>BindingPattern : ArrayBindingPattern</emu-grammar>
-      <emu-alg>
-        1. Let _iteratorRecord_ be ? GetIterator(_value_, ~sync~).
-        1. Let _result_ be Completion(IteratorBindingInitialization of |ArrayBindingPattern| with arguments _iteratorRecord_ and _environment_).
-        1. If _iteratorRecord_.[[Done]] is *false*, return ? IteratorClose(_iteratorRecord_, _result_).
-        1. Return ? _result_.
-      </emu-alg>
-      <emu-grammar>ObjectBindingPattern : `{` `}`</emu-grammar>
+      <emu-grammar>ArrayBindingPattern : `[` `]`</emu-grammar>
       <emu-alg>
         1. Return ~unused~.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` Elision `]`</emu-grammar>
+      <emu-alg>
+        1. Return ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` Elision? BindingRestElement `]`</emu-grammar>
+      <emu-alg>
+        1. If |Elision| is present, then
+          1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+        1. Return ? IteratorBindingInitialization of |BindingRestElement| with arguments _iteratorRecord_ and _environment_.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision `]`</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorBindingInitialization of |BindingElementList| with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+      </emu-alg>
+      <emu-grammar>ArrayBindingPattern : `[` BindingElementList `,` Elision? BindingRestElement `]`</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorBindingInitialization of |BindingElementList| with arguments _iteratorRecord_ and _environment_.
+        1. If |Elision| is present, then
+          1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+        1. Return ? IteratorBindingInitialization of |BindingRestElement| with arguments _iteratorRecord_ and _environment_.
+      </emu-alg>
+      <emu-grammar>BindingElementList : BindingElementList `,` BindingElisionElement</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorBindingInitialization of |BindingElementList| with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorBindingInitialization of |BindingElisionElement| with arguments _iteratorRecord_ and _environment_.
+      </emu-alg>
+      <emu-grammar>BindingElisionElement : Elision BindingElement</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+        1. Return ? IteratorBindingInitialization of |BindingElement| with arguments _iteratorRecord_ and _environment_.
+      </emu-alg>
+      <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
+      <emu-alg>
+        1. Let _bindingId_ be the StringValue of |BindingIdentifier|.
+        1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
+        1. Let _v_ be *undefined*.
+        1. If _iteratorRecord_.[[Done]] is *false*, then
+          1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+          1. If _next_ is not ~done~, then
+            1. Set _v_ to _next_.
+        1. If |Initializer| is present and _v_ is *undefined*, then
+          1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
+            1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _bindingId_.
+          1. Else,
+            1. Let _defaultValue_ be ? Evaluation of |Initializer|.
+            1. Set _v_ to ? GetValue(_defaultValue_).
+        1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
+        1. Return ? InitializeReferencedBinding(_lhs_, _v_).
+      </emu-alg>
+      <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
+      <emu-alg>
+        1. Let _v_ be *undefined*.
+        1. If _iteratorRecord_.[[Done]] is *false*, then
+          1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+          1. If _next_ is not ~done~, then
+            1. Set _v_ to _next_.
+        1. If |Initializer| is present and _v_ is *undefined*, then
+          1. Let _defaultValue_ be ? Evaluation of |Initializer|.
+          1. Set _v_ to ? GetValue(_defaultValue_).
+        1. Return ? BindingInitialization of |BindingPattern| with arguments _v_ and _environment_.
+      </emu-alg>
+      <ins class="block">
+      <emu-grammar>BindingElement : `void`</emu-grammar>
+      <emu-alg>
+        1. If _iteratorRecord_.[[Done]] is *false*, then
+          1. Perform ? IteratorStepValue(_iteratorRecord_).
+        1. Return ~unused~.
+      </emu-alg>
+      </ins>
+      <emu-grammar>BindingRestElement : `...` BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Let _lhs_ be ? ResolveBinding(StringValue of |BindingIdentifier|, _environment_).
+        1. Let _A_ be ! ArrayCreate(0).
+        1. Let _n_ be 0.
+        1. Repeat,
+          1. Let _next_ be ~done~.
+          1. If _iteratorRecord_.[[Done]] is *false*, then
+            1. Set _next_ to ? IteratorStepValue(_iteratorRecord_).
+          1. If _next_ is ~done~, then
+            1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _A_).
+            1. Return ? InitializeReferencedBinding(_lhs_, _A_).
+          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _next_).
+          1. Set _n_ to _n_ + 1.
+      </emu-alg>
+      <emu-grammar>BindingRestElement : `...` BindingPattern</emu-grammar>
+      <emu-alg>
+        1. Let _A_ be ! ArrayCreate(0).
+        1. Let _n_ be 0.
+        1. Repeat,
+          1. Let _next_ be ~done~.
+          1. If _iteratorRecord_.[[Done]] is *false*, then
+            1. Set _next_ to ? IteratorStepValue(_iteratorRecord_).
+          1. If _next_ is ~done~, then
+            1. Return ? BindingInitialization of |BindingPattern| with arguments _A_ and _environment_.
+          1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _next_).
+          1. Set _n_ to _n_ + 1.
+      </emu-alg>
+      <emu-grammar>FormalParameters : [empty]</emu-grammar>
+      <emu-alg>
+        1. Return ~unused~.
+      </emu-alg>
+      <emu-grammar>FormalParameters : FormalParameterList `,` FunctionRestParameter</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorBindingInitialization of |FormalParameterList| with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorBindingInitialization of |FunctionRestParameter| with arguments _iteratorRecord_ and _environment_.
+      </emu-alg>
+      <emu-grammar>FormalParameterList : FormalParameterList `,` FormalParameter</emu-grammar>
+      <emu-alg>
+        1. Perform ? IteratorBindingInitialization of |FormalParameterList| with arguments _iteratorRecord_ and _environment_.
+        1. Return ? IteratorBindingInitialization of |FormalParameter| with arguments _iteratorRecord_ and _environment_.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : BindingIdentifier</emu-grammar>
+      <emu-alg>
+        1. Let _v_ be *undefined*.
+        1. Assert: _iteratorRecord_.[[Done]] is *false*.
+        1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+        1. If _next_ is not ~done~, then
+          1. Set _v_ to _next_.
+        1. Return ? BindingInitialization of |BindingIdentifier| with arguments _v_ and _environment_.
+      </emu-alg>
+      <emu-grammar>ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
+      <emu-alg>
+        1. Let _formals_ be the |ArrowFormalParameters| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
+        1. Return ? IteratorBindingInitialization of _formals_ with arguments _iteratorRecord_ and _environment_.
       </emu-alg>
       <emu-grammar>
-        ObjectBindingPattern :
-          `{` BindingPropertyList `}`
-          `{` BindingPropertyList `,` `}`
+        AsyncArrowBindingIdentifier : BindingIdentifier
       </emu-grammar>
       <emu-alg>
-        1. Perform ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
-        1. Return ~unused~.
-      </emu-alg>
-      <emu-grammar>ObjectBindingPattern : `{` BindingRestProperty `}`</emu-grammar>
-      <emu-alg>
-        1. Let _excludedNames_ be a new empty List.
-        1. Return ? RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
-      </emu-alg>
-      <emu-grammar>ObjectBindingPattern : `{` BindingPropertyList `,` BindingRestProperty `}`</emu-grammar>
-      <emu-alg>
-        1. Let _excludedNames_ be ? PropertyBindingInitialization of |BindingPropertyList| with arguments _value_ and _environment_.
-        1. Return ? RestBindingInitialization of |BindingRestProperty| with arguments _value_, _environment_, and _excludedNames_.
+        1. Let _v_ be *undefined*.
+        1. Assert: _iteratorRecord_.[[Done]] is *false*.
+        1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+        1. If _next_ is not ~done~, then
+          1. Set _v_ to _next_.
+        1. Return ? BindingInitialization of |BindingIdentifier| with arguments _v_ and _environment_.
       </emu-alg>
     </emu-clause>
+
   </emu-clause>
 </emu-clause>
 
@@ -818,6 +913,7 @@ contributors: Ron Buckton, Ecma International
         <ins class="block">
         <emu-grammar>AssignmentElement : `void`</emu-grammar>
         <emu-alg>
+          1. Perform ? GetV(_value_, _propertyName_).
           1. Return ~unused~.
         </emu-alg>
         </ins>
@@ -967,6 +1063,50 @@ contributors: Ron Buckton, Ecma International
           `...` BindingIdentifier[?Yield, ?Await]
           `...` BindingPattern[?Yield, ?Await]
       </emu-grammar>
+
+      <emu-clause id="sec-runtime-semantics-keyedbindinginitialization" type="sdo" number="3">
+        <h1>
+          Runtime Semantics: KeyedBindingInitialization (
+            _value_: an ECMAScript language value,
+            _environment_: an Environment Record or *undefined*,
+            _propertyName_: a property key,
+          ): either a normal completion containing ~unused~ or an abrupt completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-note>
+          <p>When *undefined* is passed for _environment_ it indicates that a PutValue operation should be used to assign the initialization value. This is the case for formal parameter lists of non-strict functions. In that case the formal parameter bindings are preinitialized in order to deal with the possibility of multiple parameters with the same name.</p>
+        </emu-note>
+        <emu-grammar>BindingElement : BindingPattern Initializer?</emu-grammar>
+        <emu-alg>
+          1. Let _v_ be ? GetV(_value_, _propertyName_).
+          1. If |Initializer| is present and _v_ is *undefined*, then
+            1. Let _defaultValue_ be ? Evaluation of |Initializer|.
+            1. Set _v_ to ? GetValue(_defaultValue_).
+          1. Return ? BindingInitialization of |BindingPattern| with arguments _v_ and _environment_.
+        </emu-alg>
+        <ins class="block">
+        <emu-grammar>BindingElement : `void`</emu-grammar>
+        <emu-alg>
+          1. Perform ? GetV(_value_, _propertyName_).
+          1. Return ~unused~.
+        </emu-alg>
+        </ins>
+        <emu-grammar>SingleNameBinding : BindingIdentifier Initializer?</emu-grammar>
+        <emu-alg>
+          1. Let _bindingId_ be the StringValue of |BindingIdentifier|.
+          1. Let _lhs_ be ? ResolveBinding(_bindingId_, _environment_).
+          1. Let _v_ be ? GetV(_value_, _propertyName_).
+          1. If |Initializer| is present and _v_ is *undefined*, then
+            1. If IsAnonymousFunctionDefinition(|Initializer|) is *true*, then
+              1. Set _v_ to ? NamedEvaluation of |Initializer| with argument _bindingId_.
+            1. Else,
+              1. Let _defaultValue_ be ? Evaluation of |Initializer|.
+              1. Set _v_ to ? GetValue(_defaultValue_).
+          1. If _environment_ is *undefined*, return ? PutValue(_lhs_, _v_).
+          1. Return ? InitializeReferencedBinding(_lhs_, _v_).
+        </emu-alg>
+      </emu-clause>
     </emu-clause>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
The syntactic refactor in #9 is missing semantics for IteratorBindingInitialization and  KeyedBindingInitialization. This also fixes a missing algorithm step in IteratorDestructuringAssignmentEvaluation where the getter is not evaluated.